### PR TITLE
Drop Python 3.9 support

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}

--- a/cli-python/setup.py
+++ b/cli-python/setup.py
@@ -25,7 +25,7 @@ setup(
     ],
     keywords='theia editor',
     packages=find_packages(),
-    python_requires='>=3.9',
+    python_requires='>=3.10',
     install_requires=[
         'requests',
     ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Drop Python 3.9 support from the Python CLI package (`cli-python`).

[Python 3.9 reached end-of-life on 2025-10-04.](https://devguide.python.org/versions/)

## Changes

- **`.github/workflows/mypy.yml`**: Remove `"3.9"` from the `python-version` CI matrix (now tests `3.10`–`3.13`).
- **`cli-python/setup.py`**: Bump `python_requires` from `>=3.9` to `>=3.10`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1ae9582c-6a69-479b-9c6b-d6541f93f3bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1ae9582c-6a69-479b-9c6b-d6541f93f3bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

